### PR TITLE
Use php-cs-fixer/shim as replacement for friendsofphp/php-cs-fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
         "ext-json": "*",
         "ext-tokenizer": "*"
     },
+    "replace": {
+        "friendsofphp/php-cs-fixer": "self.version"
+    },
     "suggest": {
         "ext-dom": "For handling output formats in XML",
         "ext-mbstring": "For handling non-UTF8 characters."


### PR DESCRIPTION
Currently if some package requires `friendsofphp/php-cs-fixer` it is not possible to install it with `php-cs-fixer/shim`.

This PR will allow that.