### PR TITLE
Fix: Remove trailing comma

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "bin": [
         "php-cs-fixer",
-        "php-cs-fixer.phar",
+        "php-cs-fixer.phar"
     ],
     "config": {
         "sort-packages": true


### PR DESCRIPTION
This pull request

- [x] removes a trailing comma from `composer.json`

Follows #2.